### PR TITLE
complete return value

### DIFF
--- a/decgen/undef.cpp
+++ b/decgen/undef.cpp
@@ -62,4 +62,5 @@ bool compute_undef(vector<DecodeEntry>& entries)
 	for (pat_it = results.begin(); pat_it!=results.end(); pat_it++) {
 		entries.push_back(pattern2entry(*pat_it));
 	}
+	return true;
 }


### PR DESCRIPTION
`compute_undef` 's return value is unused. However, every funtion, without the return value's type is `void`, should return some value.
