### PR TITLE
add const (`char *` -> `const char*`)

### DIFF
--- a/decgen/parse_idef.y
+++ b/decgen/parse_idef.y
@@ -24,7 +24,7 @@ extern "C" {
 int yylex();
 }
 
-void yyerror(char *);
+void yyerror(const char *);
 extern void push_entry(char *, char *, char *, double);
 
 extern int mylineno;
@@ -60,7 +60,7 @@ stmt:	IDEF LBRAC IDENT COMMA HCONST COMMA HCONST COMMA FCONST RBRAC {
 
 %%
 
-void yyerror (char *s)
+void yyerror (const char *s)
 {
 	std::cerr << s << " near line " << mylineno+1 << std::endl;
 }


### PR DESCRIPTION
C++11 or later, the type of string literal(with no pre-fix) is `const char*`, not `char*`.
